### PR TITLE
save pdf name in db as stored in filesystem (#67)

### DIFF
--- a/server/antibodyapi/import_antibodies/__init__.py
+++ b/server/antibodyapi/import_antibodies/__init__.py
@@ -80,6 +80,7 @@ def import_antibodies(): # pylint: disable=too-many-branches
                                         avr_file
                                     )
                                     query = insert_query_with_avr_file_and_uuid()
+                                    row['avr_filename'] = secure_filename(row['avr_filename'])
                     try:
                         cur.execute(query, row)
                         uuids_and_names.append({


### PR DESCRIPTION
The .pdf file is saved to the database as it is written to the file system at the PSC.