### PR TITLE
Forward docker logs to AWS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,9 @@ instance/
 
 **/venv/
 
+# Ignore docker env file
+.env
+
 server/BUILD
 server/VERSION
 BUILD

--- a/docker-compose.deployment.yml
+++ b/docker-compose.deployment.yml
@@ -28,6 +28,13 @@ services:
       - ./server/log:/app/server/log
       - ./VERSION:/app/server/VERSION
       - ./BUILD:/app/server/BUILD
+    # Send docker logs to AWS CloudWatch
+    logging: 
+      driver: awslogs
+      options:
+        awslogs-region: us-east-1
+        awslogs-group: antibody-api-docker-logs
+        awslogs-stream: ${LOG_STREAM}
 
 networks:
   gateway_hubmap:

--- a/example.env
+++ b/example.env
@@ -1,0 +1,1 @@
+LOG_STREAM=DEV

--- a/server/uwsgi.ini
+++ b/server/uwsgi.ini
@@ -5,8 +5,9 @@ chdir = /app/server
 # Application's callable
 module = wsgi:application
 
-# Location of uwsgi log file
-logto = /app/server/log/uwsgi-antibody-api.log
+# Delegate the logging to the master process 
+# Send logs to stdout instead of file so docker picks it up and writes to AWS CloudWatch
+log-master=true
 
 # Master with 2 worker process (based on CPU number)
 master = true


### PR DESCRIPTION
Forward uWSGI docker logs to the AWS CloudWatch via an environment file.