### PR TITLE
Downgraded elesticsearch Python package because of The client noticed…

### DIFF
--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -13,12 +13,12 @@ services:
   elasticsearch:
     environment:
       - discovery.type=single-node
-    image: elasticsearch:7.4.2
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.10.2
     ports:
       - '9200:9200'
       - '9300:9300'
   kibana:
-    image: kibana:7.4.2
+    image: docker.elastic.co/kibana/kibana:7.10.2
     ports:
       - '5601:5601'
   mockserver:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,7 @@
-# You need to use the same major version here as is used by the server
-elasticsearch==7.17.9
+# You need to use the same major version here as is used by the elesticsearch server.
+# Why this version of elasticsearch is the highest that we can go before the server is upgraded --\/
+# https://stackoverflow.com/questions/68992402/elasticsearch-error-the-client-noticed-that-the-server-is-not-a-supported-dist
+elasticsearch==7.13.4
 Flask==3.0.3
 globus-sdk==3.41.0
 html5lib==1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
-# You need to use the same major version here as is used by the server
-elasticsearch==7.17.9
+# You need to use the same major version here as is used by the elesticsearch server.
+# Why this version of elasticsearch is the highest that we can go before the server is upgraded --\/
+# https://stackoverflow.com/questions/68992402/elasticsearch-error-the-client-noticed-that-the-server-is-not-a-supported-dist
+elasticsearch==7.13.4
 Flask==3.0.3
 globus-sdk==3.41.0
 html5lib==1.1

--- a/scripts/rebuild_elasticsearch_index.sh
+++ b/scripts/rebuild_elasticsearch_index.sh
@@ -18,7 +18,7 @@
 
 echo "Rebuild the ElasticSearch index..."
 
-ANTIBODY_URL_LOCAL='https://localhost:5000'
+ANTIBODY_URL_LOCAL='http://localhost:5000'
 ANTIBODY_URL_DEV='https://avr.dev.hubmapconsortium.org'
 ANTIBODY_URL_TEST='https://avr.test.hubmapconsortium.org'
 ANTIBODY_URL_PROD='https://avr.hubmapconsortium.org'


### PR DESCRIPTION
… that the server is not a supported distribution of Elasticsearch? error message.

If this does not work.... I may have to drop the elasticsearch package lower, but it is already 3 years old!!!
