### PR TITLE
fixed an instance of a 406 error accidentally getting caught by a gen…

### DIFF
--- a/server/antibodyapi/hubmap/templates/base.html
+++ b/server/antibodyapi/hubmap/templates/base.html
@@ -228,16 +228,16 @@ function ajaxSuccess (event) {
     return;
   }
   if (http_status == 201) {
-      var csv_content = "antibody_name,antibody_uuid\n";
+      var csv_content = "antibody_name,antibody_hubmap_id\n";
       responsetable += '<p>All entities in the Andibody Files have been successfully uploaded.</p>';
       responsetable += '<br>';
-      responsetable += '<table><tr><th>Antibody</th><th>UUID</th></tr>';
+      responsetable += '<table><tr><th>Antibody</th><th>HuBMAP ID</th></tr>';
       jQuery.each(jsonresponse.antibodies, function(name, value) {
         responsetable += '<tr>';
         responsetable += '<td>' + value.antibody_name + '</td>';
-        responsetable += '<td>' + value.antibody_uuid + '</td>';
+        responsetable += '<td>' + value.antibody_hubmap_id + '</td>';
         responsetable += '</tr>';
-        csv_content += value.antibody_name + ',' + value.antibody_uuid + '\n';
+        csv_content += value.antibody_name + ',' + value.antibody_hubmap_id + '\n';
       })
       responsetable += '</table>';
       if (jsonresponse.pdf_files_not_processed.length > 0) {

--- a/server/antibodyapi/import_antibodies/__init__.py
+++ b/server/antibodyapi/import_antibodies/__init__.py
@@ -56,7 +56,7 @@ def import_antibodies(): # pylint: disable=too-many-branches
 
     app = current_app
     cur = get_cursor(app)
-    uuids_and_names = []
+    hubmap_ids_and_names = []
 
     group_id = get_group_id(app.config['INGEST_API_URL'], request.form.get('group_id'))
     if group_id is None:
@@ -154,8 +154,8 @@ def import_antibodies(): # pylint: disable=too-many-branches
                         logger.debug(f"import_antibodies: SQL inserting row: {row}")
                         cur.execute(query, row)
                         logger.debug(f"import_antibodies: SQL inserting row SUCCESS!")
-                        uuids_and_names.append({
-                            'antibody_uuid': row['antibody_uuid'],
+                        hubmap_ids_and_names.append({
+                            'antibody_hubmap_id': row['antibody_hubmap_id'],
                             'antibody_name': row.get('avr_pdf_filename')
                         })
                         try:
@@ -185,4 +185,4 @@ def import_antibodies(): # pylint: disable=too-many-branches
     for avr_file in request.files.getlist('pdf'):
         if avr_file.filename not in pdf_files_processed:
             pdf_files_not_processed.append(avr_file.filename)
-    return make_response(jsonify(antibodies=uuids_and_names, pdf_files_not_processed=pdf_files_not_processed), 201)
+    return make_response(jsonify(antibodies=hubmap_ids_and_names, pdf_files_not_processed=pdf_files_not_processed), 201)

--- a/server/antibodyapi/utils/validation/__init__.py
+++ b/server/antibodyapi/utils/validation/__init__.py
@@ -239,14 +239,15 @@ def validate_previous_version_id(row_i: int, previous_version_id: str, cur) -> N
 
         result = cur.fetchone()
 
-        if result is None:
-            abort(json_error(f"TSV file row# {row_i}: previous_revision_hubmap_id '{previous_version_id}' does not exist", 406))
-        elif result[0] is not None:
-            abort(json_error(f"TSV file row# {row_i}: previous_version_id '{previous_version_id}' "
-                             f"already has a newer version specified (next_revision_hubmap_id='{result[0]}')", 406))
     except Exception as e:
         logger.exception(f"validate_previous_version_id: Unexpected error: {e}")
         abort(json_error(f"TSV file row# {row_i}: Problem encountered while validating previous_revision_hubmap_id", 500))
+    
+    if result is None:
+            abort(json_error(f"TSV file row# {row_i}: previous_revision_hubmap_id '{previous_version_id}' does not exist", 406))
+    elif result[0] is not None:
+        abort(json_error(f"TSV file row# {row_i}: previous_version_id '{previous_version_id}' "
+                            f"already has a newer version specified (next_revision_hubmap_id='{result[0]}')", 406))
 
 
 def validate_uniprot_accession_numbers(row_i: int, uniprot_accession_numbers: str) -> None:


### PR DESCRIPTION
Per the fixes bill requested, the table showing the results of the import is now hubmap_id not uuid. 

Also found why that specific error was showing a general 500 rather than the specific 406. The 406 was inside the try/catch meant for database read errors. It now shows the correct error message when trying to provided a previous_version_id for an antibody that already has at least one revision