### PR TITLE
Added link to general docs and rearanged link order

### DIFF
--- a/server/antibodyapi/hubmap/static/js/components/Search.js
+++ b/server/antibodyapi/hubmap/static/js/components/Search.js
@@ -73,11 +73,14 @@ function Search(props) {
         </svg>
       </a>
      <div className='topmenuRight'>
-        <a href="https://zenodo.org/doi/10.5281/zenodo.7418623" target='_blank' style={{display: "inline-block", color: "white", alignItems: "center", margin: "20px"}}>
-          AVR SOP        
-        </a>
         <a href="https://hubmapconsortium.org/open-working-groups" target='_blank' style={{display: "inline-block", color: "white", alignItems: "center", margin: "20px"}}>
           About AVRs at ARWG
+        </a>
+         <a href="https://docs.hubmapconsortium.org/avr/index.html" target='_blank' style={{display: "inline-block", color: "white", alignItems: "center", margin: "20px"}}>
+          HuBMAP AVRs
+        </a>
+         <a href="https://zenodo.org/doi/10.5281/zenodo.7418623" target='_blank' style={{display: "inline-block", color: "white", alignItems: "center", margin: "20px"}}>
+          AVR SOP        
         </a>
         <a href="/upload" style={{display: "inline-block", color: "white", alignItems: "center", margin: "20px"}}>
           Add AVRs


### PR DESCRIPTION
In the menu bar:
 - Added a link to the new index.html in the AVR docs
 - Moved the working group link to the left